### PR TITLE
Update redis.clients:jedis from 3.5.1 to 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>3.5.1</version>
+            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
I determined that `redis.clients:jedis` could be updated from `3.5.1` to `3.5.2`.

:warning: **Please ensure that this change does not break your build before merging!** :warning: