### PR TITLE
Update org.testcontainers:junit-jupiter from 1.15.1 to 1.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.15.1</version>
+            <version>1.15.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
I determined that `org.testcontainers:junit-jupiter` could be updated from `1.15.1` to `1.15.2`.

:warning: **Please ensure that this change does not break your build before merging!** :warning: