### PR TITLE
Update org.testcontainers:testcontainers from 1.15.1 to 1.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.15.1</version>
+            <version>1.15.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I determined that `org.testcontainers:testcontainers` could be updated from `1.15.1` to `1.15.2`.

:warning: **Please ensure that this change does not break your build before merging!** :warning: